### PR TITLE
frombytes() vs fromstring()

### DIFF
--- a/src/graphics.py
+++ b/src/graphics.py
@@ -127,7 +127,12 @@ class RenderSnowflake(object):
         log(msg)
         content = str.join('', [str.join('', map(chr, scheme(cell))) for cell in self.cells])
         img = Image.new("RGB", (self.lattice.size, self.lattice.size))
-        img.fromstring(content)
+        ##pillow has removed fromstring(). Use frombytes() instead. STH 2016.1212
+        try:
+            img.fromstring(content)
+        except:
+            img.frombytes(content)
+
         del content
 
         # post-process


### PR DESCRIPTION
pillow has removed the fromstring() function. It recommends using
frombytes() instead. Put the fix in a try so it should continue to work
with older versions